### PR TITLE
Add post search and return navigation

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -1,0 +1,6 @@
++++
+title = "Search"
+description = "Search posts by title, topic, or keyword."
+layout = "search"
+url = "/search/"
++++

--- a/hugo.toml
+++ b/hugo.toml
@@ -40,6 +40,11 @@ googleAnalytics = "G-2C8HSWCCE5"
     name = "Posts"
     url = "/posts/"
     weight = -200
+  [[menu.main]]
+    identifier = "search"
+    name = "Search"
+    url = "/search/"
+    weight = -150
 
 [markup]
   [markup.goldmark.renderer]
@@ -63,7 +68,7 @@ googleAnalytics = "G-2C8HSWCCE5"
   tag = "tags"
 
 [outputs]
-  home = ["HTML", "RSS", "JSON"]
+  home = ["HTML", "RSS", "JSON", "SearchIndex"]
   section = ["HTML"]
 
 [outputFormats.RSS]
@@ -73,5 +78,11 @@ googleAnalytics = "G-2C8HSWCCE5"
 [outputFormats.JSON]
   mediatype = "application/json"
   baseName = "feed"
+
+[outputFormats.SearchIndex]
+  mediatype = "application/json"
+  baseName = "search-index"
+  isPlainText = true
+  notAlternative = true
 
 ignoreErrors = ["error-remote-getjson"]

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="{{ .Site.LanguageCode | default "en-us" }}">
+  {{ partial "head.html" . }}
+<body>
+  <a class="skip-link" href="#main">Skip to main</a>
+  <main id="main">
+  <div class="content">
+    {{ partial "header.html" . }}
+    <section>
+      {{ .Content }}
+      <ul reversed class="list">
+        {{ range .Pages }}
+          <li>
+            {{ $url := .RelPermalink }}
+            {{ if eq $.Section "posts" }}
+              {{ $url = printf "%s?from=posts" .RelPermalink }}
+            {{ end }}
+            <a class="link" href="{{ $url }}" title="{{ .Title }}">{{ .Title }}
+            </a>
+            <hr class="hr-list">
+            <time class="g time" datetime="{{ dateFormat "2006-01-02" .Date }}">{{ dateFormat "02/01/06" .Date }}</time>
+          </li>
+        {{ end }}
+      </ul>
+    </section>
+  </div>
+</main>
+</body>
+</html>

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="{{ .Site.LanguageCode | default "en-us" }}">
+  {{ partial "head.html" . }}
+<body>
+  <a class="skip-link" href="#main">Skip to main</a>
+  <main id="main">
+    <div class="content">
+      {{ partial "header.html" . }}
+      <section class="search-page">
+        <h1>{{ .Title }}</h1>
+        <p>Search posts by title, topic, or keyword.</p>
+
+        <div id="search-app" data-index-url="{{ "search-index.json" | relURL }}">
+          <form class="search-form" role="search">
+            <label class="search-label" for="search-input">Search posts</label>
+            <input
+              class="search-input"
+              id="search-input"
+              name="q"
+              type="search"
+              placeholder="Loading posts…"
+              autocomplete="off"
+              spellcheck="false"
+              aria-describedby="search-status"
+              aria-controls="search-results"
+              disabled>
+          </form>
+
+          <p id="search-status" class="search-status" role="status" aria-live="polite">Loading posts…</p>
+          <ol id="search-results" class="search-results" aria-label="Search results"></ol>
+        </div>
+
+        <noscript>
+          <p>Search requires JavaScript. You can still browse every post from the <a href="{{ "/posts/" | relURL }}">posts page</a>.</p>
+        </noscript>
+      </section>
+    </div>
+  </main>
+  <script src="{{ "/js/search.js" | relURL }}" defer></script>
+</body>
+</html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,6 +7,11 @@
   <div class="content">
     {{ partial "header.html" . }}
     <section>
+      {{ if eq .Section "posts" }}
+      <nav id="post-return" class="post-return" aria-label="Return to post listing" hidden>
+        <a id="back-to-list" href="{{ "/posts/" | relURL }}">← Back to posts</a>
+      </nav>
+      {{ end }}
       <h2 class="post">{{ .Title }}</h2>
       {{ .Content }}
       {{ if eq .Section "posts" }}
@@ -31,5 +36,8 @@
     {{ end }}
   </div>
 </main>
+{{ if eq .Section "posts" }}
+<script src="{{ "/js/post-return.js" | relURL }}" defer></script>
+{{ end }}
 </body>
 </html>

--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -1,0 +1,14 @@
+{{- $posts := (where .Site.RegularPages "Section" "posts").ByDate.Reverse -}}
+[
+  {{- range $index, $post := $posts }}
+  {{- if $index }},{{ end }}
+  {
+    "title": {{ $post.Title | jsonify }},
+    "description": {{ $post.Description | default $post.Summary | plainify | htmlUnescape | jsonify }},
+    "tags": {{ $post.Params.tags | default (slice) | jsonify }},
+    "content": {{ $post.Content | plainify | htmlUnescape | jsonify }},
+    "url": {{ $post.RelPermalink | jsonify }},
+    "date": {{ $post.Date.Format "2006-01-02" | jsonify }}
+  }
+  {{- end }}
+]

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -13,7 +13,79 @@
     transition: background 0.3s, opacity 0.3s;
   }
   
-  .copy-code-button:hover {
+.copy-code-button:hover {
     background: #1d4ed8;
     opacity: 1;
   }
+
+.search-form {
+  margin: 2rem 0 1rem;
+}
+
+.search-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #777;
+  border-radius: 0;
+  background: #fff;
+  color: inherit;
+  font: inherit;
+}
+
+.search-input:focus {
+  outline: 3px solid #bbb;
+  outline-offset: 2px;
+}
+
+.search-input:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.search-status {
+  min-height: 1.5rem;
+  color: #555;
+}
+
+.search-results {
+  padding: 0;
+  list-style: none;
+}
+
+.search-result {
+  padding: 1.25rem 0;
+  border-bottom: 1px dotted #ccc;
+}
+
+.search-result-title {
+  display: inline-block;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.search-result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  margin-top: 0.25rem;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.search-result-excerpt {
+  margin: 0.5rem 0 0;
+}
+
+.post-return {
+  margin: 1.5rem 0;
+}
+
+.post-return a {
+  font-weight: 600;
+}

--- a/static/js/post-return.js
+++ b/static/js/post-return.js
@@ -1,0 +1,38 @@
+(function () {
+  "use strict";
+
+  var container = document.getElementById("post-return");
+  var link = document.getElementById("back-to-list");
+  if (!container || !link) return;
+
+  var postUrl = new URL(window.location.href);
+  var source = postUrl.searchParams.get("from");
+  var targetUrl;
+
+  if (source === "search") {
+    var query = postUrl.searchParams.get("q");
+    if (!query) return;
+
+    targetUrl = new URL("/search/", window.location.origin);
+    targetUrl.searchParams.set("q", query);
+    link.textContent = "← Back to search results";
+  } else if (source === "posts") {
+    targetUrl = new URL("/posts/", window.location.origin);
+    link.textContent = "← Back to posts";
+  } else {
+    return;
+  }
+
+  link.href = targetUrl.href;
+  container.hidden = false;
+
+  link.addEventListener("click", function (event) {
+    if (!document.referrer) return;
+
+    var referrer = new URL(document.referrer);
+    if (referrer.origin === window.location.origin && referrer.pathname === targetUrl.pathname) {
+      event.preventDefault();
+      window.history.back();
+    }
+  });
+}());

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,0 +1,194 @@
+(function () {
+  "use strict";
+
+  var app = document.getElementById("search-app");
+  if (!app) return;
+
+  var form = app.querySelector(".search-form");
+  var input = document.getElementById("search-input");
+  var status = document.getElementById("search-status");
+  var results = document.getElementById("search-results");
+  var posts = [];
+  var debounceTimer;
+
+  function normalise(value) {
+    return String(value || "").toLocaleLowerCase();
+  }
+
+  function preparePost(post) {
+    var tags = Array.isArray(post.tags) ? post.tags : [];
+
+    return {
+      title: String(post.title || "Untitled post"),
+      description: String(post.description || ""),
+      tags: tags.map(String),
+      content: String(post.content || ""),
+      url: String(post.url || "#"),
+      date: String(post.date || ""),
+      searchable: {
+        title: normalise(post.title),
+        description: normalise(post.description),
+        tags: normalise(tags.join(" ")),
+        content: normalise(post.content)
+      }
+    };
+  }
+
+  function scorePost(post, query, terms) {
+    var fields = post.searchable;
+    var combined = [fields.title, fields.tags, fields.description, fields.content].join(" ");
+
+    if (!terms.every(function (term) { return combined.indexOf(term) !== -1; })) {
+      return 0;
+    }
+
+    var score = 0;
+    terms.forEach(function (term) {
+      if (fields.title.indexOf(term) !== -1) score += 12;
+      if (fields.tags.indexOf(term) !== -1) score += 8;
+      if (fields.description.indexOf(term) !== -1) score += 4;
+      if (fields.content.indexOf(term) !== -1) score += 1;
+    });
+
+    if (fields.title.indexOf(query) !== -1) score += 20;
+    if (fields.tags.indexOf(query) !== -1) score += 10;
+
+    return score;
+  }
+
+  function makeExcerpt(post, terms) {
+    var source = post.description || post.content;
+    var lowerSource = normalise(source);
+    var matchAt = -1;
+
+    terms.some(function (term) {
+      matchAt = lowerSource.indexOf(term);
+      return matchAt !== -1;
+    });
+
+    if (matchAt === -1 || source === post.description) {
+      return source.length > 220 ? source.slice(0, 217).trim() + "…" : source;
+    }
+
+    var start = Math.max(0, matchAt - 70);
+    var end = Math.min(source.length, start + 220);
+    var excerpt = source.slice(start, end).trim();
+
+    return (start > 0 ? "…" : "") + excerpt + (end < source.length ? "…" : "");
+  }
+
+  function resultUrl(postUrl, query) {
+    var url = new URL(postUrl, window.location.href);
+    url.searchParams.set("from", "search");
+    url.searchParams.set("q", query);
+    return url.href;
+  }
+
+  function renderResult(match, terms, query) {
+    var post = match.post;
+    var item = document.createElement("li");
+    var title = document.createElement("a");
+    var meta = document.createElement("div");
+    var date = document.createElement("time");
+    var excerpt = document.createElement("p");
+
+    item.className = "search-result";
+    title.className = "search-result-title";
+    title.href = resultUrl(post.url, query);
+    title.textContent = post.title;
+
+    meta.className = "search-result-meta";
+    date.dateTime = post.date;
+    date.textContent = post.date;
+    meta.appendChild(date);
+
+    if (post.tags.length) {
+      var tagText = document.createElement("span");
+      tagText.textContent = post.tags.join(" · ");
+      meta.appendChild(tagText);
+    }
+
+    excerpt.className = "search-result-excerpt";
+    excerpt.textContent = makeExcerpt(post, terms);
+
+    item.appendChild(title);
+    item.appendChild(meta);
+    item.appendChild(excerpt);
+    return item;
+  }
+
+  function updateUrl(query) {
+    var url = new URL(window.location.href);
+    if (query) url.searchParams.set("q", query);
+    else url.searchParams.delete("q");
+    window.history.replaceState({}, "", url);
+  }
+
+  function search() {
+    var rawQuery = input.value.trim();
+    var query = normalise(rawQuery).replace(/\s+/g, " ");
+    var terms = query.split(" ").filter(Boolean);
+
+    updateUrl(rawQuery);
+    results.replaceChildren();
+
+    if (query.length < 2) {
+      status.textContent = rawQuery ? "Enter at least two characters." : "Enter at least two characters to search.";
+      return;
+    }
+
+    var matches = posts
+      .map(function (post) {
+        return { post: post, score: scorePost(post, query, terms) };
+      })
+      .filter(function (match) { return match.score > 0; })
+      .sort(function (a, b) {
+        return b.score - a.score || b.post.date.localeCompare(a.post.date);
+      });
+
+    if (!matches.length) {
+      status.textContent = "No posts found for “" + rawQuery + "”.";
+      return;
+    }
+
+    status.textContent = matches.length + (matches.length === 1 ? " post found." : " posts found.");
+    var fragment = document.createDocumentFragment();
+    matches.forEach(function (match) {
+      fragment.appendChild(renderResult(match, terms, rawQuery));
+    });
+    results.appendChild(fragment);
+  }
+
+  function scheduleSearch() {
+    window.clearTimeout(debounceTimer);
+    debounceTimer = window.setTimeout(search, 120);
+  }
+
+  form.addEventListener("submit", function (event) {
+    event.preventDefault();
+    window.clearTimeout(debounceTimer);
+    search();
+  });
+  input.addEventListener("input", scheduleSearch);
+
+  fetch(app.dataset.indexUrl, { headers: { Accept: "application/json" } })
+    .then(function (response) {
+      if (!response.ok) throw new Error("Could not load the search index.");
+      return response.json();
+    })
+    .then(function (data) {
+      if (!Array.isArray(data)) throw new Error("The search index is invalid.");
+      posts = data.map(preparePost);
+      input.disabled = false;
+      input.placeholder = "Try Cypress, ETL, Playwright…";
+
+      var initialQuery = new URL(window.location.href).searchParams.get("q") || "";
+      input.value = initialQuery;
+      if (initialQuery) search();
+      else status.textContent = "Enter at least two characters to search " + posts.length + " posts.";
+    })
+    .catch(function () {
+      status.textContent = "Search is temporarily unavailable. Please try again later.";
+      input.placeholder = "Search unavailable";
+    });
+}());


### PR DESCRIPTION
## Summary

- add dependency-free client-side keyword search across post titles, tags, descriptions, and content
- generate a compact static search index during the Hugo build
- add a Search page and navigation entry with accessible result status and empty states
- preserve search queries when opening posts and returning to results
- add contextual return navigation for posts opened from the Posts page

## Why

Readers need a quick way to find posts by topic or keyword without introducing a backend or hosted search dependency. Contextual return links also make it easier to continue browsing after opening a result.

## Impact

The site remains fully static. Production builds now emit `/search-index.json`, and direct post visits remain unchanged because return navigation appears only when the post was opened from Search or Posts.

## Validation

- Hugo 0.121.2 production build
- generated index contains all 34 published posts
- JavaScript syntax checks for search and return navigation
- representative searches: Cypress, ETL, Playwright radio button, authentication, and no-result query
- direct, Posts-origin, and Search-origin return-navigation checks
- `git diff --check`