### PR TITLE
Update contact links

### DIFF
--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -52,7 +52,6 @@ hideDate: true
 
 <p class="text-center text-sm mt-6">
 Or connect with me directly:<br>
-<a href="mailto:ilesh@ileshdarji.com">ilesh@ileshdarji.com</a> | 
-<a href="https://www.linkedin.com/in/ilesh-d-25179713" target="_blank">LinkedIn</a> | 
+<a href="https://www.linkedin.com/in/ileshkumar-d-25179713/" target="_blank">LinkedIn</a> |
 <a href="https://github.com/ileshdarji" target="_blank">GitHub</a>
 </p>


### PR DESCRIPTION
## Summary

- remove the inaccessible `ilesh@ileshdarji.com` email address from the Contact page
- update LinkedIn to the current profile URL
- retain GitHub as the other direct contact option

## Why

The previous email inbox is no longer accessible, so the site should not direct visitors to it.

## Impact

The contact form remains unchanged. The direct-contact footer now contains only LinkedIn and GitHub.

## Validation

- Hugo 0.121.2 production build
- manually verified the local Contact page
- confirmed the old email and LinkedIn URL no longer appear in the site source
- `git diff --check`